### PR TITLE
Update patches and build scripts

### DIFF
--- a/patches/vyos-build/0015-add-nexttrace-repo.patch
+++ b/patches/vyos-build/0015-add-nexttrace-repo.patch
@@ -1,11 +1,11 @@
 diff --git a/data/architectures/arm64.toml b/data/architectures/arm64.toml
-index 9ed68bbb..625858bc 100644
+index 0447d846..1f2ae646 100644
 --- a/data/architectures/arm64.toml
 +++ b/data/architectures/arm64.toml
-@@ -17,3 +17,12 @@ squashfs_compression_type = "xz -b 256k -always-use-fragments -no-recovery"
-   architecture = "arm64"
-   url = "https://dl.cloudsmith.io/public/isc/kea-3-0/deb/debian"
-   distribution = "bookworm"
+@@ -12,3 +12,11 @@ squashfs_compression_type = "xz -b 256k -always-use-fragments -no-recovery"
+ 
+ [additional_repositories.zabbix]
+   url = "https://repo.zabbix.com/zabbix/6.0/debian-arm64"
 +
 +[additional_repositories.nexttrace]
 +  architecture = "arm64"
@@ -14,4 +14,3 @@ index 9ed68bbb..625858bc 100644
 +  components = ""
 +  no_source = true
 +  key = "mDMEaO7vHRYJKwYBBAHaRw8BAQdAXY+aVR+gfjDiaI1CQZXTiaOJI9ZOEziFVxQPheIyrDG0IW54dHJhY2Uub3JnIDxjb250YWN0QG54dHJhY2Uub3JnPoiTBBMWCgA7FiEEoqH7meOhHVsUbhcLNigaslezB/oFAmju7x0CGwMFCwkIBwICIgIGFQoJCAsCBBYCAwECHgcCF4AACgkQNigaslezB/rjdQD+JmXqnB3kmkKVQRfH7urC/zTkp2UkkLhUw+dykoCTggcBAK5qLKvUJN6Xu3TF0dEuBqVV9+14OkTbg4Ymaw7gUpEPuDgEaO7vHRIKKwYBBAGXVQEFAQEHQILPhsR2XsUYs7orwth28VQZRlXznHYsjCISbUb+UPgxAwEIB4h4BBgWCgAgFiEEoqH7meOhHVsUbhcLNigaslezB/oFAmju7x0CGwwACgkQNigaslezB/qHNwD/d3Yl/QhT/62Cghg575+XTEbnsrCIhazszdTd8NB4OFQA+wU421K4YjDrCAQy+C77YlRQ1pxFv3cYIMHn3H9qTEUM"
-+

--- a/scripts/patch-vyos-build-from-huihuimoe.sh
+++ b/scripts/patch-vyos-build-from-huihuimoe.sh
@@ -16,7 +16,8 @@ patch --no-backup-if-mismatch -p1 -d vyos-build < data/vyos-build-003-fix_hardco
 # fix on https://github.com/vyos/vyos-build/commit/82a40e68c7e4b3ea45fb2bbc4a1a7cff92e41942
 #patch --no-backup-if-mismatch -p1 -d vyos-build < data/vyos-build-004-fix_saltproject_package_url.patch
 patch --no-backup-if-mismatch -p1 -d vyos-build < data/vyos-build-005-add_vim_link.patch
-patch --no-backup-if-mismatch -p1 -d vyos-build < data/vyos-build-006-fix_kernel_sign.patch
+# fix on https://github.com/vyos/vyos-build/commit/7e803f5000bd77b8cb172cf31b04146c4fc76c8a
+#patch --no-backup-if-mismatch -p1 -d vyos-build < data/vyos-build-006-fix_kernel_sign.patch
 # sign kernel module but donot sign vmlinuz
 patch --no-backup-if-mismatch -p1 -d vyos-build < data/vyos-build-007-no_sbsign.patch
 patch --no-backup-if-mismatch -p1 -d vyos-build < data/vyos-build-008-fix_live_boot_initramfs_link.patch

--- a/scripts/patch-vyos-build-from-huihuimoe.sh
+++ b/scripts/patch-vyos-build-from-huihuimoe.sh
@@ -21,4 +21,3 @@ patch --no-backup-if-mismatch -p1 -d vyos-build < data/vyos-build-005-add_vim_li
 # sign kernel module but donot sign vmlinuz
 patch --no-backup-if-mismatch -p1 -d vyos-build < data/vyos-build-007-no_sbsign.patch
 patch --no-backup-if-mismatch -p1 -d vyos-build < data/vyos-build-008-fix_live_boot_initramfs_link.patch
-patch --no-backup-if-mismatch -p1 -d vyos-build < data/vyos-build-009-live_boot_serial_console_device.patch


### PR DESCRIPTION
The _vyos-build-006-fix_kernel_sign_ patch is no longer necessary since it was fixed in upstream VyOS. Causes the build script to fail.

https://github.com/vyos/vyos-build/commit/7e803f5000bd77b8cb172cf31b04146c4fc76c8a

The _0015-add-nexttrace-repo_ patch also didn't apply properly due to upstream changes.