### PR TITLE
Update patch to hardcode MAC addresses for the SFP+ interfaces too

### DIFF
--- a/patches/BPI-Router-Linux/0001-bpi-r4-eth-name.patch
+++ b/patches/BPI-Router-Linux/0001-bpi-r4-eth-name.patch
@@ -1,8 +1,28 @@
+diff --git a/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4.dts b/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4.dts
+index 499f0c91c213..cf5b6bb6adbb 100644
+--- a/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4.dts
++++ b/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4.dts
+@@ -27,6 +27,7 @@ &gmac1 {
+ 	managed = "in-band-status";
+ 	phy-mode = "usxgmii";
+ 	sfp = <&sfp2>;
++	local-mac-address = [02 00 00 b3 14 42];
+ 	status = "okay";
+ };
+ 
 diff --git a/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4.dtsi b/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4.dtsi
-index 91d39b84f3ea..54658d99f0d4 100644
+index 358ac1df35dd..14227c077027 100644
 --- a/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4.dtsi
 +++ b/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4.dtsi
-@@ -187,7 +187,8 @@ &gsw_phy0_led0 {
+@@ -166,6 +166,7 @@ &gmac2 {
+ 	managed = "in-band-status";
+ 	phy-mode = "usxgmii";
+ 	sfp = <&sfp1>;
++	local-mac-address = [02 00 00 b3 14 41];
+ 	status = "okay";
+ };
+ 
+@@ -181,7 +182,8 @@ &gsw_phy0_led0 {
  };
  
  &gsw_port0 {
@@ -12,7 +32,7 @@ index 91d39b84f3ea..54658d99f0d4 100644
  };
  
  &gsw_phy1 {
-@@ -202,7 +203,8 @@ &gsw_phy1_led0 {
+@@ -196,7 +198,8 @@ &gsw_phy1_led0 {
  };
  
  &gsw_port1 {
@@ -22,7 +42,7 @@ index 91d39b84f3ea..54658d99f0d4 100644
  };
  
  &gsw_phy2 {
-@@ -217,7 +219,8 @@ &gsw_phy2_led0 {
+@@ -211,7 +214,8 @@ &gsw_phy2_led0 {
  };
  
  &gsw_port2 {
@@ -32,7 +52,7 @@ index 91d39b84f3ea..54658d99f0d4 100644
  };
  
  &gsw_phy3 {
-@@ -232,7 +235,8 @@ &gsw_phy3_led0 {
+@@ -226,7 +230,8 @@ &gsw_phy3_led0 {
  };
  
  &gsw_port3 {


### PR DESCRIPTION
Without hardcoding the MAC addresses for the SFP+ interfaces in the device tree (or programming MAC addresses into the EEPROM using the serial console), they will change on every boot. This is clearly undesirable.